### PR TITLE
replace CRLF with LF; process csv headers; clean up code

### DIFF
--- a/source/CSVClass.cs
+++ b/source/CSVClass.cs
@@ -1,39 +1,32 @@
-﻿using System;
-using CsvHelper.Configuration;
-using CsvHelper.Configuration.Attributes;
+﻿using CsvHelper.Configuration.Attributes;
+using UAssetAPI.StructTypes;
 
 namespace Commu_Kit
 {
     public class CSVClass
     {
-        public CSVClass(string identifier, string characterName, string source, string target)
+        public CSVClass() // default constructor needed for CSV reading
         {
-            Identifier = identifier;
-            CharacterName = characterName;
-            Source = source;
-            Target = target;
         }
+
+        public CSVClass(StructPropertyData entry)
+        {
+            Identifier = entry.Name.ToString();
+            CharacterName = entry.Value[0].RawValue?.ToString() ?? "";
+            Source = entry.Value[1].RawValue?.ToString() ?? "";
+            Target = "";
+        }
+
         [Name("id")]
-        public String Identifier { get; set; }
+        public string Identifier { get; set; }
+
         [Name("character")]
-        public String CharacterName{ get; set; }
+        public string CharacterName { get; set; }
+
         [Name("source")]
-        public String Source{ get; set; }
+        public string Source { get; set; }
+
         [Name("translatedstr")]
-        public String Target{ get; set; }
-    }
-
-    public class CsvMap : ClassMap<CSVClass>
-    {
-        public CsvMap()
-        {
-            Map(m => m.Identifier).Name("id");
-            Map(m => m.CharacterName).Name("character");
-            Map(m => m.Source).Name("src");
-            Map(m => m.Target).Name("translatedstr");
-
-
-
-        }
+        public string Target { get; set; }
     }
 }

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -1,145 +1,112 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using CommandLine;
+using CsvHelper;
+using CsvHelper.Configuration;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text;
 using UAssetAPI;
-using UAssetAPI.StructTypes;
-using CommandLine;
-using CsvHelper;
-using CsvHelper.Configuration;
 using UAssetAPI.PropertyTypes;
-
 
 namespace Commu_Kit
 {
-    class Program
+    internal class Program
     {
-        const UE4Version UNREAL_VERSION = UE4Version.VER_UE4_24;
-       
+        private const UE4Version UNREAL_VERSION = UE4Version.VER_UE4_24;
+
         [Verb("export", HelpText = "Extracts commu text from .uasset files")]
-        class ExportClass
+        private class ExportClass
         {
             [Value(0, HelpText = "Input file path", MetaName = "FilePath", Required = true)]
             public string FilePath { get; set; }
-            [Option('o', HelpText = "output path")]
-            public string OutputPath { get; set; }
-        }
-        [Verb("import", HelpText = "Patches .uasset files with translation from .csv files")]
-        class ImportClass
-        {
-            [Value(0, HelpText = "Input .csv file path", MetaName = "CsvInputPath", Required = true)]
-            public string CsvInputPath { get; set; }
-            [Value(1, HelpText = "Input .uasset file path", MetaName = "UassetInputPath", Required = true)]
-            public string UassetInputPath { get; set; }
-            
+
             [Option('o', HelpText = "output path")]
             public string OutputPath { get; set; }
         }
 
-        public static string GetStringByName(IEnumerable<CSVClass> ienum, string name)
+        [Verb("import", HelpText = "Patches .uasset files with translation from .csv files")]
+        private class ImportClass
         {
-            return ienum.First(c => c.Identifier == name).Target;
+            [Value(0, HelpText = "Input .csv file path", MetaName = "CsvInputPath", Required = true)]
+            public string CsvInputPath { get; set; }
+
+            [Value(1, HelpText = "Input .uasset file path", MetaName = "UassetInputPath", Required = true)]
+            public string UassetInputPath { get; set; }
+
+            [Option('o', HelpText = "output path")]
+            public string OutputPath { get; set; }
         }
-        private static int ExportFile(ExportClass opt)
+
+        private static void ExportFile(ExportClass opt)
         {
-         
             string filePath = opt.FilePath;
             string outputFile = opt.OutputPath;
-            if (String.IsNullOrEmpty(outputFile))
+            if (string.IsNullOrEmpty(outputFile))
             {
-                outputFile = Path.GetDirectoryName(filePath) + @"\" + Path.GetFileNameWithoutExtension(filePath) + ".csv";
+                outputFile = $"{Path.GetDirectoryName(filePath)}\\{Path.GetFileNameWithoutExtension(filePath)}.csv";
                 Console.WriteLine(outputFile);
             }
 
             UAsset openFile = new UAsset(filePath, UNREAL_VERSION);
-            var DataTable = openFile.Exports[0] as DataTableExport;
-            var Table = DataTable?.Table;
-            var indexes = new[] {3, 4};
+            var Table = (openFile.Exports[0] as DataTableExport)?.Table;
+            if (Table is null)
+            {
+                throw new InvalidDataException("Could not access data table. Please check you also have the corresponding .uexp file.");
+            }
+            var quoteIndexes = new int[] { 3, 4 };
             var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
                 Delimiter = ",",
-                ShouldQuote = args => indexes.Contains(args.Row.Index)
+                ShouldQuote = args => quoteIndexes.Contains(args.Row.Index)
             };
-            using (var strWriter = new StreamWriter(outputFile))
-            using (var csvExporter = new CsvWriter(strWriter, CultureInfo.InvariantCulture))
+            using (var csvExporter = new CsvWriter(new StreamWriter(outputFile), CultureInfo.InvariantCulture))
             {
-                csvExporter.WriteHeader<CSVClass>();
-                csvExporter.NextRecord();
-                for (int i = 0; i < Table.Data.Count; i++)
-                {
-                    StructPropertyData Entry = Table.Data[i];
-                    var Data = Entry.Value[1];
-                    var SpeakerData = Entry.Value[0];
-                    var csvRow = new CSVClass(Entry.Name.ToString(), SpeakerData.RawValue + "", Data.RawValue + "", "");
-                    csvExporter.WriteRecord(csvRow);
-                    csvExporter.NextRecord();
-                  //  Console.WriteLine(
-                      //  Entry.Name + "," + SpeakerData.RawValue + "," + "\"" + Data.RawValue + "\"" + ", ");
-                }
+                var records = Table.Data.Select((entry) => new CSVClass(entry));
+                csvExporter.WriteRecords(records);
             }
             Console.WriteLine("Written to:" + outputFile);
-            
-            return 0;
         }
 
-        private static int ImportFile(ImportClass opt)
+        private static void ImportFile(ImportClass opt)
         {
-           
             string filePath = opt.CsvInputPath;
-            if (File.Exists(filePath))
-            {
-              //  Console.WriteLine(filePath);
-            }
-            else
-            {
-         //       Console.WriteLine("FileNotFound");
-            }
             string outputFile = opt.OutputPath;
-            if (String.IsNullOrEmpty(outputFile))
+            if (string.IsNullOrEmpty(outputFile))
             {
-                outputFile = Path.GetDirectoryName(filePath) + @"\" +  Path.GetFileNameWithoutExtension(filePath) + "-NEW.uasset";
+                outputFile = $"{Path.GetDirectoryName(filePath)}\\{Path.GetFileNameWithoutExtension(filePath)}-NEW.uasset";
             }
             UAsset openFile = new UAsset(opt.UassetInputPath, UNREAL_VERSION);
-            var DataTable = openFile.Exports[0] as DataTableExport;
-            var Table = DataTable?.Table;
+            var Table = (openFile.Exports[0] as DataTableExport)?.Table;
+            if (Table is null)
+            {
+                throw new InvalidDataException("Could not access data table. Please check you also have the corresponding .uexp file.");
+            }
             var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
                 Delimiter = ",",
-                HasHeaderRecord = false
+                MissingFieldFound = null
             };
-            using(var reader = new StreamReader(filePath, Encoding.UTF8))
-            using (var csv = new CsvReader(reader, csvConfig))
+            using (var csv = new CsvReader(new StreamReader(filePath, Encoding.UTF8), csvConfig))
             {
-                var records = csv.GetRecords<CSVClass>();
-                for (int i = 0; i < Table.Data.Count; i++)
+                var csvLookup = csv.GetRecords<CSVClass>().ToDictionary((entry) => entry.Identifier);
+                foreach (var entry in Table.Data)
                 {
-                    StructPropertyData Entry = Table.Data[i];
-                    var Data = Entry.Value[1];
-                    //Console.WriteLine(Entry.Name.ToString());
-                    if (Data is StrPropertyData strData) strData.Value = new FString(GetStringByName(records,Entry.Name.ToString()));
-
+                    if (entry.Value[1] is StrPropertyData strData)
+                    {
+                        strData.Value = new FString(csvLookup[entry.Name.ToString()].Target.Replace("\r\n", "\n"));
+                    }
                 }
             }
-            
             openFile.Write(outputFile);
-
-            return 0;
         }
 
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
-            Console.OutputEncoding= Encoding.Unicode;
-            var parseArgs = Parser.Default.ParseArguments<ExportClass, ImportClass>(args).MapResult(
-                (ExportClass opt) => ExportFile(opt),
-                (ImportClass opt) => ImportFile(opt),
-                errs => 1
-            );
+            Console.OutputEncoding = Encoding.Unicode;
+            Parser.Default.ParseArguments<ExportClass, ImportClass>(args)
+                .WithParsed<ExportClass>(ExportFile)
+                .WithParsed<ImportClass>(ImportFile);
         }
-
-
-
     }
 };


### PR DESCRIPTION
I noticed there were a few bugs in the csv importing:
- Messages with multiple lines were using CRLF ("\r\n") instead of LF ("\n") when reinserted into the uasset file
- The csv headers were not being processed - changing the order of the columns would import the wrong things

This branch fixes both of those bugs, as well as cleaning up code and removing unused functions.